### PR TITLE
#1 fix to bug about asynchrony

### DIFF
--- a/TriggerStorage.gs
+++ b/TriggerStorage.gs
@@ -23,7 +23,8 @@ var TriggerStorage = (function(exports) {
 	 * curry-bracket "}" is invalid function name, and not need to be escaped.
 	 * So we can safely use it as 'not-normal-trigger-name'.
 	 */
-	var PREFIX = '}';
+	var PREFIX = '}',
+		storage = {};
 
 
 	/**
@@ -35,6 +36,7 @@ var TriggerStorage = (function(exports) {
 		var name = createName(key, value);
 
 		deleteTriggerByKey(key);
+		storage[key] = value;
 
 		ScriptApp.newTrigger(name)
 			.timeBased()
@@ -53,6 +55,8 @@ var TriggerStorage = (function(exports) {
 		var triggers = ScriptApp.getProjectTriggers(),
 			reg = createNameRegExp(key),
 			ma, i, name;
+
+		if (key in storage) return storage[key];
 
 		for (i = 0; i < triggers.length; i++) {
 			name = triggers[i].getHandlerFunction();
@@ -74,6 +78,25 @@ var TriggerStorage = (function(exports) {
 		deleteTriggerByKey(key);
 	}
 	exports.clearItem = clearItem;
+
+
+	/**
+	 * Delete all triggers registered by TriggerStorage
+	 */
+	function clearItemAll() {
+		var triggers = ScriptApp.getProjectTriggers(),
+			reg = createNameRegExp(''),
+			i, trigger;
+
+		for (i = 0; i < triggers.length; i++) {
+			trigger = triggers[i];
+
+			if (reg.test(trigger.getHandlerFunction())) {
+				ScriptApp.deleteTrigger(trigger);
+			}
+		}
+	}
+	exports.clearItemAll = clearItemAll;
 
 
 	/**

--- a/sample.gs
+++ b/sample.gs
@@ -14,6 +14,10 @@
  */
 
 function from() {
+	//clear all trigger registered by TriggerStorage
+	TriggerStorage.clearItemAll();
+
+
 	//set data
 	TriggerStorage.setItem('foo', {
 		a: 1,
@@ -26,6 +30,12 @@ function from() {
 		.timeBased()
 		.after(1000 * 20) //20seconds after.
 		.create();
+
+	//check on-memory storage
+	TriggerStorage.setItem('buz', {
+		message: "Hello World!"
+	});
+	Logger.log(TriggerStorage.getItem('buz').message);
 }
 
 function to() {
@@ -36,4 +46,7 @@ function to() {
 	Logger.log('to: data.a >> ' + data.a);
 	Logger.log('to: data.b >> ' + data.b);
 	Logger.log('to: data.c >> ' + data.c);
+
+	//clear all trigger registered by TriggerStorage
+	TriggerStorage.clearItemAll();
 }


### PR DESCRIPTION
## 変更点
- `setItem()` の非同期性に関するバグの解決
- 不正なトリガーを一括削除するメソッド `clearItemAll()` の導入
## change log
- fix a bug about the asynchrony of `setItem()`
- add `clearItemAll()` , which removed all invalid triggers.
